### PR TITLE
Fix the endianness detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,9 @@ jobs:
           apt-get update -y
           DEBIAN_FRONTEND=noninteractive apt-get install -y rebar3 gcc libssl-dev
         run: |
-         echo "---rebar3 as test get-deps---"
-         rebar3 as test get-deps
-         echo "---rebar3 as test compile---"
-         rebar3 as test compile
-         echo "---rebar3 as test ct---"
-         rebar3 as test ct
+          echo "---rebar3 as test get-deps---"
+          rebar3 as test get-deps
+          echo "---rebar3 as test compile---"
+          rebar3 as test compile
+          echo "---rebar3 as test ct---"
+          rebar3 as test ct

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,24 @@ jobs:
         run: |
           pip install --user codecov
           /home/runner/.local/bin/codecov
+
+  test-on-s390x:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup emulator
+      run: |
+        sudo docker run --rm --privileged tonistiigi/binfmt:qemu-v6.2.0
+    - name: Run build
+      uses: uraimo/run-on-arch-action@v2.6.0
+      with:
+        arch: s390x
+        distro: ubuntu22.04
+        run: | 
+         apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y rebar3 gcc libssl-dev
+         echo "---rebar3 as test get-deps---"
+         rebar3 as test get-deps
+         echo "---rebar3 as test compile---"
+         rebar3 as test compile
+         echo "---rebar3 as test ct---"
+         rebar3 as test ct

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,10 @@ jobs:
       with:
         arch: s390x
         distro: ubuntu22.04
-        run: | 
-         apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y rebar3 gcc libssl-dev
+        install: |
+          apt-get update -y
+          DEBIAN_FRONTEND=noninteractive apt-get install -y rebar3 gcc libssl-dev
+        run: |
          echo "---rebar3 as test get-deps---"
          rebar3 as test get-deps
          echo "---rebar3 as test compile---"

--- a/c_src/fast_pbkdf2.c
+++ b/c_src/fast_pbkdf2.c
@@ -38,7 +38,7 @@
 
 static inline void write32_be(uint32_t n, uint8_t out[4])
 {
-#if defined(__GNUC__) && __GNUC__ >= 4 && __BYTE_ORDER == __LITTLE_ENDIAN
+#if defined(__GNUC__) && __GNUC__ >= 4 && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   *(uint32_t *)(out) = __builtin_bswap32(n);
 #else
   out[0] = (n >> 24) & 0xff;
@@ -50,7 +50,7 @@ static inline void write32_be(uint32_t n, uint8_t out[4])
 
 static inline void write64_be(uint64_t n, uint8_t out[8])
 {
-#if defined(__GNUC__) &&  __GNUC__ >= 4 && __BYTE_ORDER == __LITTLE_ENDIAN
+#if defined(__GNUC__) &&  __GNUC__ >= 4 && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   *(uint64_t *)(out) = __builtin_bswap64(n);
 #else
   write32_be((n >> 32) & 0xffffffff, out);


### PR DESCRIPTION
The current BYTE_ORDER check is not detecting big endian correctly and test failures were observed because of this. 
With this fix, all tests pass on s390x(big endian). Also this does not affect amd64 results.

Will fix https://github.com/esl/fast_pbkdf2/issues/11