### PR TITLE
Add `-Wundef` to compile options

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
       {port_env,
         [
           {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-               "CFLAGS", "$CFLAGS -std=c99 -O0 -g -Wall -Wextra -fPIC -I/opt/homebrew/include -I/usr/local/include --coverage"},
+               "CFLAGS", "$CFLAGS -std=c99 -O0 -g -Wall -Wextra -Wundef -fPIC -I/opt/homebrew/include -I/usr/local/include --coverage"},
           {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
                "LDLIBS", "$LDLIBS -lcrypto -L/opt/homebrew/lib/ -L/usr/local/lib --coverage"}
         ]
@@ -30,7 +30,7 @@
 {port_env,
   [
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-         "CFLAGS", "$CFLAGS -std=c99 -O3 -g -Wall -Wextra -fPIC -I/opt/homebrew/include -I/usr/local/include"},
+         "CFLAGS", "$CFLAGS -std=c99 -O3 -g -Wall -Wextra -Wundef -fPIC -I/opt/homebrew/include -I/usr/local/include"},
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
          "LDLIBS", "$LDLIBS -lcrypto -L/opt/homebrew/lib/ -L/usr/local/lib"},
     {"win32", "CFLAGS", "$CFLAGS /I${OPENSSL_INSTALL_DIR}/include /O2 /DNDEBUG /Wall"},

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
       {port_env,
         [
           {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-               "CFLAGS", "$CFLAGS -std=c99 -O0 -g -Wall -Wextra -Wundef -fPIC -I/opt/homebrew/include -I/usr/local/include --coverage"},
+               "CFLAGS", "$CFLAGS -std=c99 -O0 -g -Wall -Wextra -Wundef -Werror=undef -fPIC -I/opt/homebrew/include -I/usr/local/include --coverage"},
           {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
                "LDLIBS", "$LDLIBS -lcrypto -L/opt/homebrew/lib/ -L/usr/local/lib --coverage"}
         ]
@@ -30,7 +30,7 @@
 {port_env,
   [
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-         "CFLAGS", "$CFLAGS -std=c99 -O3 -g -Wall -Wextra -Wundef -fPIC -I/opt/homebrew/include -I/usr/local/include"},
+         "CFLAGS", "$CFLAGS -std=c99 -O3 -g -Wall -Wextra -Wundef -Werror=undef -fPIC -I/opt/homebrew/include -I/usr/local/include"},
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
          "LDLIBS", "$LDLIBS -lcrypto -L/opt/homebrew/lib/ -L/usr/local/lib"},
     {"win32", "CFLAGS", "$CFLAGS /I${OPENSSL_INSTALL_DIR}/include /O2 /DNDEBUG /Wall"},


### PR DESCRIPTION
Give a warning for undefined macros to prevent errors like #11.