### PR TITLE
Fix uninitialized pointer in PBKDF2 macro

### DIFF
--- a/c_src/fast_pbkdf2.c
+++ b/c_src/fast_pbkdf2.c
@@ -210,7 +210,7 @@ typedef struct {
     /* - The final result is copied to the output buffer and returned */                           \
     ERL_NIF_TERM PBKDF2_F_MD(_name)(ErlNifEnv * env, const int argc, const ERL_NIF_TERM argv[]) {  \
         const pbkdf2_st *const mod_st = enif_priv_data(env);                                       \
-        HMAC_CTX_ROUND(_name) *const restrict round_st;                                            \
+        HMAC_CTX_ROUND(_name) *restrict round_st;                                            \
         if (!enif_get_resource(env, argv[0], mod_st->HMAC_CTX_ROUND_RES(_name),                    \
                                (void *)(&round_st))) {                                             \
             return enif_make_badarg(env);                                                          \


### PR DESCRIPTION
This PR fixes a compilation error caused by an uninitialized pointer in the PBKDF2 macro.

**Error:**

```
===> /Users/kamilwaz/Workspace/esl/fast_pbkdf2.git/x-main/c_src/fast_pbkdf2.c:381:1: error: default initialization of an object of type 'HMAC_sha1_ctx_round *const restrict' leaves the object uninitialized [-Werror,-Wdefault-const-init-var-unsafe]
  381 | DECL_PBKDF2(sha1, SHA_CBLOCK, SHA_DIGEST_LENGTH, 3350 / SLICE)
      | ^
/Users/kamilwaz/Workspace/esl/fast_pbkdf2.git/x-main/c_src/fast_pbkdf2.c:213:47: note: expanded from macro 'DECL_PBKDF2'
  213 |         HMAC_CTX_ROUND(_name) *const restrict round_st;

```

**Environment:**

```
$ cc --version
Apple clang version 21.0.0 (clang-2100.0.123.102)
Target: arm64-apple-darwin25.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```
